### PR TITLE
Change hardcoding of alpha variable in mix_up function in mixup example

### DIFF
--- a/examples/vision/mixup.py
+++ b/examples/vision/mixup.py
@@ -117,7 +117,7 @@ def mix_up(ds_one, ds_two, alpha=0.2):
     batch_size = tf.shape(images_one)[0]
 
     # Sample lambda and reshape it to do the mixup
-    l = sample_beta_distribution(batch_size, 0.2, 0.2)
+    l = sample_beta_distribution(batch_size, alpha, alpha)
     x_l = tf.reshape(l, (batch_size, 1, 1, 1))
     y_l = tf.reshape(l, (batch_size, 1))
 


### PR DESCRIPTION
This removes the hardcoding of the alpha variable in the `mix_up` function in the mixup example.